### PR TITLE
Fixes CI/CD for frontend

### DIFF
--- a/.github/workflows/deploy_front.yml
+++ b/.github/workflows/deploy_front.yml
@@ -2,7 +2,7 @@ name: Frontend - Build & Lint
 
 on:
   pull_request:
-    branches: [ develop ]
+    branches: [ main ]
 
 jobs:
   frontend-check:

--- a/.github/workflows/deploy_front.yml
+++ b/.github/workflows/deploy_front.yml
@@ -8,8 +8,8 @@ jobs:
   frontend-check:
     runs-on: ubuntu-latest
     env:
-      VITE_API_URL=https://videoo-call.onrender.com
-      VITE_WS_URL=wss://videoo-call.onrender.com
+      VITE_API_URL: https://videoo-call.onrender.com
+      VITE_WS_URL: wss://videoo-call.onrender.com
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow configuration by changing the syntax used to define environment variables in the `frontend-check` job. The change switches from using `=` to `:` for assigning values to `VITE_API_URL` and `VITE_WS_URL` in `.github/workflows/deploy_front.yml`.