### PR TITLE
Fixes Build errors

### DIFF
--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -90,10 +90,8 @@ export const useWebSocket = (
 
   useEffect(() => {
     connect();
-    let isMounted = true;
 
     return () => {
-      isMounted = false;
       if (reconnectTimeoutRef.current) {
         clearTimeout(reconnectTimeoutRef.current);
         reconnectTimeoutRef.current = undefined;


### PR DESCRIPTION
This pull request makes a minor cleanup to the `useWebSocket` hook by removing the unused `isMounted` variable, which was no longer necessary.