### PR TITLE
Use API for TURN server credentials

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,11 @@
+# Backend API URLs
+VITE_API_URL=http://localhost:8000
+VITE_WS_URL=ws://localhost:8000
+
+# Production URLs (uncomment when deploying)
+# VITE_API_URL=https://videoo-call.onrender.com
+# VITE_WS_URL=wss://videoo-call.onrender.com
+
+# Metered TURN Server API Key
+# Get your API key from: https://www.metered.ca/
+VITE_METERED_API_KEY=your_metered_api_key_here

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -2,31 +2,35 @@
 export const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000';
 export const WS_BASE_URL = import.meta.env.VITE_WS_URL || 'ws://localhost:8000';
 
-// WebRTC Configuration with STUN and TURN servers
+// Metered TURN Server API configuration
+export const METERED_API_KEY = import.meta.env.VITE_METERED_API_KEY;
+export const METERED_API_URL = `https://linkup-ufazien.metered.live/api/v1/turn/credentials?apiKey=${METERED_API_KEY}`;
+
+// Function to fetch TURN server credentials
+export const fetchIceServers = async (): Promise<RTCIceServer[]> => {
+  try {
+    const response = await fetch(METERED_API_URL);
+    if (!response.ok) {
+      throw new Error('Failed to fetch TURN credentials');
+    }
+    const iceServers = await response.json();
+    return iceServers;
+  } catch (error) {
+    console.error('Error fetching ICE servers:', error);
+    // Fallback to Google STUN servers if Metered API fails
+    return [
+      {
+        urls: 'stun:stun.l.google.com:19302'
+      }
+    ];
+  }
+};
+
+// Default RTC configuration (will be updated with fetched credentials)
 export const RTC_CONFIG: RTCConfiguration = {
   iceServers: [
     {
-      urls: 'stun:stun.relay.metered.ca:80'
-    },
-    {
-      urls: 'turn:global.relay.metered.ca:80',
-      username: '81df41330ffff0c3d75e77ed',
-      credential: 'yn1jtZhMFeVgGmYo'
-    },
-    {
-      urls: 'turn:global.relay.metered.ca:80?transport=tcp',
-      username: '81df41330ffff0c3d75e77ed',
-      credential: 'yn1jtZhMFeVgGmYo'
-    },
-    {
-      urls: 'turn:global.relay.metered.ca:443',
-      username: '81df41330ffff0c3d75e77ed',
-      credential: 'yn1jtZhMFeVgGmYo'
-    },
-    {
-      urls: 'turns:global.relay.metered.ca:443?transport=tcp',
-      username: '81df41330ffff0c3d75e77ed',
-      credential: 'yn1jtZhMFeVgGmYo'
+      urls: 'stun:stun.l.google.com:19302'
     }
   ]
 };


### PR DESCRIPTION
This pull request updates the WebRTC connection logic to dynamically fetch TURN server credentials from the Metered API, improving security and flexibility. The changes remove hardcoded credentials, introduce environment variable configuration, and refactor the WebRTC hook to asynchronously retrieve ICE server information before establishing peer connections.

Configuration and Environment Updates:
* Added new environment variables in `.env.example` for API URLs and the Metered TURN Server API key, supporting both development and production setups.

WebRTC TURN/STUN Server Handling:
* Refactored `config.ts` to remove hardcoded TURN/STUN credentials and add logic for fetching dynamic credentials from the Metered API using the provided API key. Includes a fallback to Google STUN servers if fetching fails.

WebRTC Hook Refactoring:
* Updated `useWebRTC.ts` to use the new `fetchIceServers` function, caching credentials for reuse and ensuring ICE servers are fetched before creating peer connections. [[1]](diffhunk://#diff-5dace9a47d3b041b85a8c7bfbe2860d3f65b691650e83df13bfbfc006d0cb332L2-R2) [[2]](diffhunk://#diff-5dace9a47d3b041b85a8c7bfbe2860d3f65b691650e83df13bfbfc006d0cb332R22) [[3]](diffhunk://#diff-5dace9a47d3b041b85a8c7bfbe2860d3f65b691650e83df13bfbfc006d0cb332L42-R51)
* Refactored peer connection creation and offer handling to be asynchronous, awaiting ICE server retrieval before proceeding. [[1]](diffhunk://#diff-5dace9a47d3b041b85a8c7bfbe2860d3f65b691650e83df13bfbfc006d0cb332L174-R182) [[2]](diffhunk://#diff-5dace9a47d3b041b85a8c7bfbe2860d3f65b691650e83df13bfbfc006d0cb332L222-R230)