### PR TITLE
Develop --> Main

### DIFF
--- a/.github/workflows/deploy_front.yml
+++ b/.github/workflows/deploy_front.yml
@@ -10,6 +10,7 @@ jobs:
     env:
       VITE_API_URL: https://videoo-call.onrender.com
       VITE_WS_URL: wss://videoo-call.onrender.com
+      VITE_METERED_API_KEY:  ${{ secrets.VITE_METERED_API_KEY }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,11 @@
+# Backend API URLs
+VITE_API_URL=http://localhost:8000
+VITE_WS_URL=ws://localhost:8000
+
+# Production URLs (uncomment when deploying)
+# VITE_API_URL=https://videoo-call.onrender.com
+# VITE_WS_URL=wss://videoo-call.onrender.com
+
+# Metered TURN Server API Key
+# Get your API key from: https://www.metered.ca/
+VITE_METERED_API_KEY=your_metered_api_key_here

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -2,31 +2,35 @@
 export const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000';
 export const WS_BASE_URL = import.meta.env.VITE_WS_URL || 'ws://localhost:8000';
 
-// WebRTC Configuration with STUN and TURN servers
+// Metered TURN Server API configuration
+export const METERED_API_KEY = import.meta.env.VITE_METERED_API_KEY;
+export const METERED_API_URL = `https://linkup-ufazien.metered.live/api/v1/turn/credentials?apiKey=${METERED_API_KEY}`;
+
+// Function to fetch TURN server credentials
+export const fetchIceServers = async (): Promise<RTCIceServer[]> => {
+  try {
+    const response = await fetch(METERED_API_URL);
+    if (!response.ok) {
+      throw new Error('Failed to fetch TURN credentials');
+    }
+    const iceServers = await response.json();
+    return iceServers;
+  } catch (error) {
+    console.error('Error fetching ICE servers:', error);
+    // Fallback to Google STUN servers if Metered API fails
+    return [
+      {
+        urls: 'stun:stun.l.google.com:19302'
+      }
+    ];
+  }
+};
+
+// Default RTC configuration (will be updated with fetched credentials)
 export const RTC_CONFIG: RTCConfiguration = {
   iceServers: [
     {
-      urls: 'stun:stun.relay.metered.ca:80'
-    },
-    {
-      urls: 'turn:global.relay.metered.ca:80',
-      username: '81df41330ffff0c3d75e77ed',
-      credential: 'yn1jtZhMFeVgGmYo'
-    },
-    {
-      urls: 'turn:global.relay.metered.ca:80?transport=tcp',
-      username: '81df41330ffff0c3d75e77ed',
-      credential: 'yn1jtZhMFeVgGmYo'
-    },
-    {
-      urls: 'turn:global.relay.metered.ca:443',
-      username: '81df41330ffff0c3d75e77ed',
-      credential: 'yn1jtZhMFeVgGmYo'
-    },
-    {
-      urls: 'turns:global.relay.metered.ca:443?transport=tcp',
-      username: '81df41330ffff0c3d75e77ed',
-      credential: 'yn1jtZhMFeVgGmYo'
+      urls: 'stun:stun.l.google.com:19302'
     }
   ]
 };


### PR DESCRIPTION
This pull request updates the WebRTC configuration to dynamically fetch TURN server credentials from the Metered API, improving security and flexibility. It removes hardcoded credentials from the codebase and updates environment configuration and workflow files to support the new approach.

### WebRTC Configuration & TURN Server Credentials

* Replaced hardcoded Metered TURN server credentials in `RTC_CONFIG` with logic to fetch credentials dynamically from the Metered API using the `VITE_METERED_API_KEY` environment variable in `config.ts`. This also introduces a fallback to Google's public STUN server if fetching fails.
* Refactored the `useWebRTC` hook to use the new `fetchIceServers` function for initializing peer connections, ensuring credentials are fetched once and cached for reuse. All peer connection creation logic now awaits the dynamic fetching of ICE servers. [[1]](diffhunk://#diff-5dace9a47d3b041b85a8c7bfbe2860d3f65b691650e83df13bfbfc006d0cb332L2-R2) [[2]](diffhunk://#diff-5dace9a47d3b041b85a8c7bfbe2860d3f65b691650e83df13bfbfc006d0cb332R22) [[3]](diffhunk://#diff-5dace9a47d3b041b85a8c7bfbe2860d3f65b691650e83df13bfbfc006d0cb332L42-R51) [[4]](diffhunk://#diff-5dace9a47d3b041b85a8c7bfbe2860d3f65b691650e83df13bfbfc006d0cb332L174-R182) [[5]](diffhunk://#diff-5dace9a47d3b041b85a8c7bfbe2860d3f65b691650e83df13bfbfc006d0cb332L222-R230)

### Environment & Deployment Configuration

* Added `VITE_METERED_API_KEY` to the `.env.example` file with instructions for obtaining the key, and clarified usage for local and production API URLs.
* Updated the GitHub Actions deployment workflow to inject the Metered API key from repository secrets for production deployments.